### PR TITLE
Update types file to use new default export syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,4 +13,4 @@ uniqueString();
 */
 declare function uniqueString(): string;
 
-export = uniqueString;
+export default uniqueString;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
 import {expectType} from 'tsd';
-import uniqueString = require('.');
+import uniqueString from '.';
 
 expectType<string>(uniqueString());


### PR DESCRIPTION
Hi,

Using the old syntax for default export makes an error with ESLint and the import plugin. More details: https://github.com/benmosher/eslint-plugin-import/issues/558#issue-176588156

This patch uses the new syntax.